### PR TITLE
refactor: limit to `githubreleases` update source

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -15,4 +15,4 @@ bot:
   automerge: true
   version_updates:
     sources:
-      - GithubReleases
+      - githubreleases

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -14,5 +14,5 @@ test: native_and_emulated
 bot:
   automerge: true
   version_updates:
-    allowed_tag_globs: 
-      - '[0-9]*'
+    sources:
+      - GithubReleases


### PR DESCRIPTION
By default, all sources are enabled and the `github` update source (atom feed with all releases of a repo incl. side-packages) currently has a bug when tags contain forward slashes, cf. https://github.com/regro/cf-scripts/pull/5928.

This change works around this problem by only checking GitHub's `/releases/latest` API endpoint which is automatically limited to the primary latest release, ignoring side-packages like `sass_api`.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
